### PR TITLE
Error fix: now python3 compatible

### DIFF
--- a/cocoLRPapi-master/PythonAPI/pycocotools/cocoevalLRP.py
+++ b/cocoLRPapi-master/PythonAPI/pycocotools/cocoevalLRP.py
@@ -320,7 +320,7 @@ class COCOevalLRP:
             tps = np.squeeze(np.logical_and(               dtm,  np.logical_not(dtIg) )*1)
             fps = np.squeeze(np.logical_and(np.logical_not(dtm), np.logical_not(dtIg) )*1)
             IoUoverlap=np.multiply(IoUoverlap,tps)
-            np.set_printoptions(threshold=np.nan)
+            np.set_printoptions(threshold=sys.maxsize)
             for s, s0 in enumerate(_pe.confScores):
                 thrind=np.sum(dtScoresSorted>=s0)
                 omega[s,k]=np.sum(tps[0:thrind])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+cython
+matplotlib
+scikit-image


### PR DESCRIPTION
- PR for issue #7
- Tested in python2 environment and it works well with `np.set_printoptions(threshold=sys.maxsize)`
- Add requirements.txt